### PR TITLE
test: stub outlook client for email scanner

### DIFF
--- a/tests/test_email_scanner.py
+++ b/tests/test_email_scanner.py
@@ -1,18 +1,55 @@
-"""
-Test-Suite für den E-Mail Scanner
-"""
-import pytest
+"""Test-Suite für den E-Mail Scanner."""
+
+from unittest.mock import MagicMock, patch
+import sys
+
+sys.modules["win32com"] = MagicMock()
+sys.modules["win32com.client"] = MagicMock()
+sys.modules["google"] = MagicMock()
+sys.modules["google.oauth2"] = MagicMock()
+sys.modules["google.oauth2.credentials"] = MagicMock()
+sys.modules["google_auth_oauthlib"] = MagicMock()
+sys.modules["google_auth_oauthlib.flow"] = MagicMock()
+sys.modules["google.auth"] = MagicMock()
+sys.modules["google.auth.transport"] = MagicMock()
+sys.modules["google.auth.transport.requests"] = MagicMock()
+sys.modules["msal"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+sys.modules["colorama"] = MagicMock()
+mock_traffic_light = MagicMock()
+mock_traffic_light.analyze_threat_level = MagicMock()
+sys.modules["analyzer.traffic_light"] = mock_traffic_light
+
 from analyzer.email_scanner import get_outlook_emails
 
-def test_get_outlook_emails():
-    """Test der Outlook E-Mail Abruf Funktion"""
-    emails = get_outlook_emails(max_count=1)
-    assert isinstance(emails, list), "Emails sollten als Liste zurückgegeben werden"
 
-    if emails:
-        email = emails[0]
-        assert isinstance(email, dict), "Jede E-Mail sollte ein Dictionary sein"
-        assert "subject" in email, "E-Mail sollte einen Betreff haben"
-        assert "sender" in email, "E-Mail sollte einen Absender haben"
-        assert "body" in email, "E-Mail sollte einen Body haben"
-        assert "attachments" in email, "E-Mail sollte Anhänge-Information haben"
+def test_get_outlook_emails():
+    """Testet den E-Mail-Abruf über einen gestubbten Outlook-Client."""
+    dummy_emails = [
+        {
+            "subject": "Hallo",
+            "sender": "alice@example.com",
+            "body": "Willkommen",
+            "attachments": [],
+        },
+        {
+            "subject": "Report",
+            "sender": "bob@example.com",
+            "body": "Siehe Anhang",
+            "attachments": ["report.pdf"],
+        },
+    ]
+
+    mock_scanner = MagicMock()
+    mock_scanner.get_emails.return_value = dummy_emails
+
+    with patch("analyzer.email_scanner.get_scanner", return_value=mock_scanner):
+        emails = get_outlook_emails(max_count=2)
+
+    assert emails == dummy_emails
+    assert len(emails) == 2
+
+    first_email = emails[0]
+    assert first_email["subject"] == "Hallo"
+    assert first_email["sender"] == "alice@example.com"
+    assert first_email["attachments"] == []


### PR DESCRIPTION
## Summary
- mock Outlook client to avoid real connections in email scanner tests
- add dummy email data and assertions

## Testing
- `python -m pytest tests/test_email_scanner.py`
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pip install beautifulsoup4 transformers` *(fails: Could not find a version that satisfies the requirement beautifulsoup4)*
- `flake8 tests/test_email_scanner.py` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_688ce137abe8832889ec6488c786a3b7