### PR TITLE
Fix scan_inbox call and add tests

### DIFF
--- a/analyzer/__init__.py
+++ b/analyzer/__init__.py
@@ -4,7 +4,8 @@ Dieses Paket enthält die Hauptkomponenten für die E-Mail-Analyse.
 """
 
 from .email_scanner import get_outlook_emails
-from .traffic_light import analyze_threat_level
 from .utils import setup_logging
+
+__all__ = ["get_outlook_emails", "setup_logging"]
 
 __version__ = '0.1.0'

--- a/analyzer/email_scanner.py
+++ b/analyzer/email_scanner.py
@@ -116,8 +116,20 @@ def determine_risk_level(issues):
     else:
         return "green"
 
-def scan_inbox(folder_name="Posteingang", max_count=20, trusted_domains=None):
-    emails = get_outlook_emails(folder_name, max_count)
+def scan_inbox(folder_name: str = "Posteingang", max_count: int = 20, trusted_domains=None):
+    """Scannt E-Mails im Posteingang und bewertet deren Risiko.
+
+    Args:
+        folder_name (str): Name des Outlook-Ordners. Der Parameter ist
+            aktuell nur ein Platzhalter und hat keine Auswirkung.
+        max_count (int): Maximale Anzahl abzurufender E-Mails.
+        trusted_domains (list[str] | None): Liste vertrauenswürdiger Domains,
+            die bei der Bewertung berücksichtigt werden.
+
+    Returns:
+        List[Dict]: Eine Liste mit Ergebnissen pro E-Mail.
+    """
+    emails = get_outlook_emails(max_count=max_count)
     results = []
     for email in emails:
         risk, issues = scan_email(email, trusted_domains=trusted_domains)
@@ -125,7 +137,7 @@ def scan_inbox(folder_name="Posteingang", max_count=20, trusted_domains=None):
             "subject": email["subject"],
             "sender": email["sender"],
             "risk": risk,
-            "issues": issues
+            "issues": issues,
         })
     return results
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Test configuration and environment stubs."""
+
+import sys
+import types
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    sys.modules.setdefault(name, module)
+    return sys.modules[name]
+
+
+# Stub ``win32com`` so that Outlook-related modules can be imported on systems
+# without the actual dependency.
+win32com = _ensure_module("win32com")
+win32com.client = _ensure_module("win32com.client")
+
+
+# Stub a minimal subset of the Google modules used by ``gmail.py``. Only the
+# attributes accessed during import are provided.
+google = _ensure_module("google")
+google.oauth2 = _ensure_module("google.oauth2")
+google.oauth2.credentials = _ensure_module("google.oauth2.credentials")
+google.oauth2.credentials.Credentials = object
+
+google_auth_oauthlib = _ensure_module("google_auth_oauthlib")
+google_auth_oauthlib.flow = _ensure_module("google_auth_oauthlib.flow")
+google_auth_oauthlib.flow.InstalledAppFlow = object
+
+google.auth = _ensure_module("google.auth")
+google.auth.transport = _ensure_module("google.auth.transport")
+google.auth.transport.requests = _ensure_module("google.auth.transport.requests")
+google.auth.transport.requests.Request = object
+
+# Stub "msal" for Exchange client imports.
+_ensure_module("msal")
+
+# ``requests`` is imported by the Exchange client but not used in tests.
+_ensure_module("requests")
+
+# Minimal stub for ``colorama`` used by the traffic light module.
+colorama = _ensure_module("colorama")
+colorama.Fore = types.SimpleNamespace(RED="", YELLOW="", GREEN="", WHITE="")
+colorama.Style = types.SimpleNamespace(RESET_ALL="")
+colorama.init = lambda *args, **kwargs: None
+

--- a/tests/test_email_scanner.py
+++ b/tests/test_email_scanner.py
@@ -1,11 +1,29 @@
-"""
-Test-Suite für den E-Mail Scanner
-"""
-import pytest
-from analyzer.email_scanner import get_outlook_emails
+"""Tests for the e-mail scanner module."""
 
-def test_get_outlook_emails():
-    """Test der Outlook E-Mail Abruf Funktion"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from analyzer import email_scanner
+from analyzer.email_scanner import get_outlook_emails, scan_inbox
+
+
+def test_get_outlook_emails(monkeypatch):
+    """Ensure ``get_outlook_emails`` returns a list of e-mails."""
+
+    class DummyScanner:
+        def get_emails(self, max_count):
+            return [
+                {
+                    "subject": "Test",
+                    "sender": "tester@example.com",
+                    "body": "",
+                    "attachments": [],
+                }
+            ]
+
+    monkeypatch.setattr(email_scanner, "get_scanner", lambda: DummyScanner())
+
     emails = get_outlook_emails(max_count=1)
     assert isinstance(emails, list), "Emails sollten als Liste zurückgegeben werden"
 
@@ -16,3 +34,22 @@ def test_get_outlook_emails():
         assert "sender" in email, "E-Mail sollte einen Absender haben"
         assert "body" in email, "E-Mail sollte einen Body haben"
         assert "attachments" in email, "E-Mail sollte Anhänge-Information haben"
+
+
+def test_scan_inbox_uses_max_count(monkeypatch):
+    """``scan_inbox`` should forward only ``max_count`` to ``get_outlook_emails``."""
+
+    dummy_email = {
+        "subject": "Hallo",
+        "sender": "user@example.com",
+        "body": "",
+        "attachments": [],
+    }
+
+    mock_get = MagicMock(return_value=[dummy_email])
+    monkeypatch.setattr(email_scanner, "get_outlook_emails", mock_get)
+
+    results = scan_inbox(folder_name="ignored", max_count=5)
+
+    mock_get.assert_called_once_with(max_count=5)
+    assert results[0]["subject"] == "Hallo"


### PR DESCRIPTION
## Summary
- Fix `scan_inbox` to pass only `max_count` to `get_outlook_emails` and document parameters
- Expose only available utilities in package `__init__`
- Add unit tests for `get_outlook_emails` and `scan_inbox`
- Stub external dependencies for tests

## Testing
- `python -m py_compile analyzer/email_scanner.py tests/test_email_scanner.py tests/conftest.py analyzer/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_688ce1208eb08328a16ed4142acce785