### PR TITLE
Add progress dialog and datetime imports to main window

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -4,11 +4,12 @@ Hauptfenster der Mail Analyzer GUI
 import sys
 import os
 import configparser
+from datetime import datetime
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
     QListWidget, QListWidgetItem, QLabel, QTextEdit, QPushButton,
-    QTabWidget, QSplitter, QProgressBar, QMessageBox, QComboBox,
-    QDialog, QFormLayout, QLineEdit, QDialogButtonBox, QMenu
+    QTabWidget, QSplitter, QProgressBar, QProgressDialog, QMessageBox,
+    QComboBox, QDialog, QFormLayout, QLineEdit, QDialogButtonBox, QMenu
 )
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QColor, QFont, QAction


### PR DESCRIPTION
## Summary
- prepare main window for progress and timestamp features

## Testing
- `pytest` *(fails: AssertionError in tests/test_traffic_light.py::test_display_threat_level, tests/test_traffic_light.py::test_get_recommendation)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_688cf2de6d388328b2e22b2dfc67b042