### PR TITLE
Handle dict data in cluster view

### DIFF
--- a/gui/threat_dashboard.py
+++ b/gui/threat_dashboard.py
@@ -9,12 +9,10 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtChart import (
     QChart, QChartView, QPieSeries, QLineSeries,
-    QValueAxis, QBarSeries, QBarSet
+    QValueAxis, QBarSeries
 )
-import pandas as pd
-import numpy as np
-from typing import Dict, List
-from datetime import datetime, timedelta
+from typing import Dict
+from datetime import datetime
 
 class ThreatDashboard(QWidget):
     def __init__(self, threat_analyzer, parent=None):
@@ -289,12 +287,24 @@ class ThreatDashboard(QWidget):
             self.cluster_layout.itemAt(i).widget().setParent(None)
 
         # Füge neue Cluster hinzu
-        for cluster_id, data in clusters.get('clusters', {}).items():
+        for cluster_id, emails in clusters.get("clusters", {}).items():
             label = QLabel(f"Cluster {cluster_id}")
             label.setStyleSheet("font-weight: bold;")
             self.cluster_layout.addWidget(label)
 
-            details = QLabel(f"Größe: {len(data)}\nHäufige Merkmale: {', '.join(data[:3])}")
+            # Extrahiere aussagekräftige Strings aus den E-Mail-Dicts (z.B. Betreff)
+            subjects = [
+                str(email.get("subject", "")).strip()
+                for email in emails
+                if isinstance(email, dict)
+            ]
+            subjects = [s for s in subjects if s]
+
+            details_text = f"Größe: {len(emails)}"
+            if subjects:
+                details_text += f"\nHäufige Merkmale: {', '.join(subjects[:3])}"
+
+            details = QLabel(details_text)
             self.cluster_layout.addWidget(details)
 
     def _update_forecasts(self, trends: Dict):

--- a/tests/test_email_scanner.py
+++ b/tests/test_email_scanner.py
@@ -3,7 +3,6 @@
 
 import sys
 from unittest.mock import MagicMock, patch
-import pytest
 
 # Externe Abhängigkeiten mocken, damit Imports in email_scanner nicht fehlschlagen
 sys.modules["win32com"] = MagicMock()
@@ -23,8 +22,11 @@ mock_traffic_light = MagicMock()
 mock_traffic_light.analyze_threat_level = MagicMock()
 sys.modules["analyzer.traffic_light"] = mock_traffic_light
 
-import analyzer.email_scanner
-from analyzer.email_scanner import get_outlook_emails, scan_inbox
+import analyzer.email_scanner  # noqa: E402
+from analyzer.email_scanner import get_outlook_emails, scan_inbox  # noqa: E402
+
+# Ursprüngliches TrafficLight-Modul für nachfolgende Tests wiederherstellen
+sys.modules.pop("analyzer.traffic_light", None)
 
 
 def test_get_outlook_emails_dummy_scanner():


### PR DESCRIPTION
## Summary
- Show cluster size and top subjects by extracting `subject` from each email dict
- Restore `analyzer.traffic_light` module in email scanner tests to avoid cross-test interference

## Testing
- `ruff check gui/threat_dashboard.py`
- `ruff check tests/test_email_scanner.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cf2e539e48328a584210a9a602084