### PR TITLE
Optimize email scanning and stabilize tests

### DIFF
--- a/tests/test_email_scanner.py
+++ b/tests/test_email_scanner.py
@@ -28,9 +28,6 @@ from analyzer.email_scanner import get_outlook_emails, scan_inbox  # noqa: E402
 # Ursprüngliches TrafficLight-Modul für nachfolgende Tests wiederherstellen
 sys.modules.pop("analyzer.traffic_light", None)
 
-# Entferne Stub, damit andere Tests das echte Modul laden können
-del sys.modules["analyzer.traffic_light"]
-
 
 def test_get_outlook_emails_dummy_scanner():
     """Testet den E-Mail-Abruf über einen gestubbten Outlook-Client."""


### PR DESCRIPTION
## Summary
- optimize email keyword and link analysis using pre-lowered text and compiled regex patterns
- document risk mapping logic with type hints and Google-style docstring
- stabilize email scanner tests by removing redundant module cleanup

## Testing
- `pytest -q`
- `pip install flake8 -q` *(fails: ProxyError: Cannot connect to proxy)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cfcbe21888328b8f7ea4520a51c3f