### PR TITLE
[mail_analyzer] Add setup script for dependencies

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Upgrade pip to ensure latest package management features
+python -m pip install --upgrade pip
+
+# Install runtime dependencies
+python -m pip install \
+    numpy \
+    pandas \
+    matplotlib \
+    joblib \
+    httpx \
+    requests \
+    schedule \
+    scikit-learn \
+    PyQt6
+
+# Install development tools
+python -m pip install \
+    pytest \
+    flake8


### PR DESCRIPTION
## Summary
- add `setup.sh` script to install runtime and development dependencies

## Testing
- `pytest`
- `pip install flake8` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688d0435c030832889233e79e1dcbd63