### PR TITLE
[mail_analyzer] Modularize GUI components

### DIFF
--- a/analyzer/email_controller.py
+++ b/analyzer/email_controller.py
@@ -1,0 +1,27 @@
+"""Controller for retrieving and analyzing emails."""
+
+from typing import List, Tuple, Dict
+
+
+class EmailController:
+    """Handle email fetching and analysis."""
+
+    def __init__(self, scanner, analyzer) -> None:
+        self._scanner = scanner
+        self._analyzer = analyzer
+
+    def fetch_emails(self, max_count: int) -> List[Tuple[Dict, Dict]]:
+        """Fetch emails and return analysis results.
+
+        Args:
+            max_count: Maximum number of emails to retrieve.
+
+        Returns:
+            List[Tuple[Dict, Dict]]: Pairs of raw email data and analysis results.
+        """
+        emails = self._scanner.get_emails(max_count=max_count)
+        results: List[Tuple[Dict, Dict]] = []
+        for email in emails:
+            analysis = self._analyzer.analyze_email(email)
+            results.append((email, analysis))
+        return results

--- a/analyzer/report_controller.py
+++ b/analyzer/report_controller.py
@@ -1,0 +1,37 @@
+"""Controller coordinating report generation and statistics."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+class ReportController:
+    """Aggregate email data and delegate report creation."""
+
+    def __init__(self, generator) -> None:
+        self._generator = generator
+
+    def _collect_emails(self, list_widget) -> List[Dict[str, Any]]:
+        """Extract email and analysis data from a QListWidget-like object."""
+        emails: List[Dict[str, Any]] = []
+        for i in range(list_widget.count()):
+            item = list_widget.item(i)
+            email_data = item.email_data.copy()
+            email_data.update(item.analysis_result)
+            email_data["timestamp"] = datetime.now().isoformat()
+            emails.append(email_data)
+        return emails
+
+    def create_pdf_report(self, list_widget) -> Optional[str]:
+        """Create a PDF report from the given widget contents."""
+        emails = self._collect_emails(list_widget)
+        return self._generator.create_pdf_report(emails)
+
+    def create_excel_report(self, list_widget) -> Optional[str]:
+        """Create an Excel report from the given widget contents."""
+        emails = self._collect_emails(list_widget)
+        return self._generator.create_excel_report(emails)
+
+    def create_statistical_analysis(self, list_widget) -> Optional[Dict[str, Any]]:
+        """Generate statistical summaries for the given emails."""
+        emails = self._collect_emails(list_widget)
+        return self._generator.create_statistical_analysis(emails)

--- a/gui/client_settings_dialog.py
+++ b/gui/client_settings_dialog.py
@@ -1,0 +1,79 @@
+"""Dialog to configure email client settings."""
+
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+)
+
+
+class ClientSettingsDialog(QDialog):
+    """Modal dialog for editing client connection settings.
+
+    Attributes:
+        config: ConfigParser object with current settings.
+    """
+
+    def __init__(self, config, parent=None):
+        super().__init__(parent)
+        self.config = config
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        """Construct the dialog layout."""
+        self.setWindowTitle("E-Mail-Client Einstellungen")
+        layout = QFormLayout()
+
+        # Client selection
+        self.client_combo = QComboBox()
+        self.client_combo.addItems(["outlook", "gmail", "exchange"])
+        current_client = self.config.get("EMAIL", "client", fallback="outlook")
+        self.client_combo.setCurrentText(current_client)
+        layout.addRow("E-Mail-Client:", self.client_combo)
+
+        # Gmail settings
+        self.gmail_creds = QLineEdit(
+            self.config.get("GMAIL", "credentials_file", fallback="credentials.json")
+        )
+        layout.addRow("Gmail Credentials File:", self.gmail_creds)
+
+        # Exchange settings
+        self.exchange_client_id = QLineEdit(
+            self.config.get("EXCHANGE", "client_id", fallback="")
+        )
+        self.exchange_tenant_id = QLineEdit(
+            self.config.get("EXCHANGE", "tenant_id", fallback="")
+        )
+        self.exchange_secret = QLineEdit(
+            self.config.get("EXCHANGE", "client_secret", fallback="")
+        )
+        self.exchange_secret.setEchoMode(QLineEdit.EchoMode.Password)
+        layout.addRow("Exchange Client ID:", self.exchange_client_id)
+        layout.addRow("Exchange Tenant ID:", self.exchange_tenant_id)
+        layout.addRow("Exchange Client Secret:", self.exchange_secret)
+
+        # Dialog buttons
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+        self.setLayout(layout)
+
+    def get_settings(self) -> dict:
+        """Return the user-specified settings.
+
+        Returns:
+            dict: Mapping of setting names to values.
+        """
+        return {
+            "client": self.client_combo.currentText(),
+            "gmail_credentials": self.gmail_creds.text(),
+            "exchange_client_id": self.exchange_client_id.text(),
+            "exchange_tenant_id": self.exchange_tenant_id.text(),
+            "exchange_secret": self.exchange_secret.text(),
+        }

--- a/gui/email_list_item.py
+++ b/gui/email_list_item.py
@@ -1,0 +1,27 @@
+"""List item representing a scanned email."""
+
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import QListWidgetItem
+
+from config.settings import THREAT_LEVELS
+
+
+class EmailListItem(QListWidgetItem):
+    """Display an email with color-coding for threat level."""
+
+    def __init__(self, email_data: dict, analysis_result: dict) -> None:
+        super().__init__()
+        self.email_data = email_data
+        self.analysis_result = analysis_result
+        self.setText(f"{email_data['subject'][:50]}...")
+        self._set_color_by_threat_level()
+
+    def _set_color_by_threat_level(self) -> None:
+        """Apply background color according to the threat level."""
+        level = self.analysis_result["level"]
+        if level == THREAT_LEVELS["HIGH"]:
+            self.setBackground(QColor(255, 200, 200))  # light red
+        elif level == THREAT_LEVELS["MEDIUM"]:
+            self.setBackground(QColor(255, 255, 200))  # light yellow
+        else:
+            self.setBackground(QColor(200, 255, 200))  # light green

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -4,140 +4,98 @@ Hauptfenster der Mail Analyzer GUI
 import sys
 import os
 import configparser
-from datetime import datetime
 from PyQt6.QtWidgets import (
-    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
-    QListWidget, QListWidgetItem, QLabel, QTextEdit, QPushButton,
-    QTabWidget, QSplitter, QProgressBar, QProgressDialog, QMessageBox,
-    QComboBox, QDialog, QFormLayout, QLineEdit, QDialogButtonBox, QMenu
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QMainWindow,
+    QProgressBar,
+    QProgressDialog,
+    QPushButton,
+    QSplitter,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+    QMessageBox,
 )
 from PyQt6.QtCore import Qt, QTimer
-from PyQt6.QtGui import QColor, QFont, QAction, QDesktopServices, QUrl
+from PyQt6.QtGui import QFont, QAction, QDesktopServices, QUrl
 
 from analyzer.email_scanner import get_scanner
 from analyzer.threat_analyzer import ThreatAnalyzer
 from analyzer.traffic_light import TrafficLight
 from analyzer.update_manager import UpdateManager
-from config.settings import MAX_EMAILS_TO_SCAN, THREAT_LEVELS
 from analyzer.report_generator import ReportGenerator
+from analyzer.email_controller import EmailController
+from analyzer.report_controller import ReportController
+from config.settings import MAX_EMAILS_TO_SCAN
 from .threat_dashboard import ThreatDashboard
 from .context_config import ContextRuleConfig
-
-class ClientSettingsDialog(QDialog):
-    def __init__(self, config, parent=None):
-        super().__init__(parent)
-        self.config = config
-        self.initUI()
-
-    def initUI(self):
-        self.setWindowTitle('E-Mail-Client Einstellungen')
-        layout = QFormLayout()
-
-        # Client-Auswahl
-        self.client_combo = QComboBox()
-        self.client_combo.addItems(['outlook', 'gmail', 'exchange'])
-        current_client = self.config.get('EMAIL', 'client', fallback='outlook')
-        self.client_combo.setCurrentText(current_client)
-        layout.addRow('E-Mail-Client:', self.client_combo)
-
-        # Gmail-Einstellungen
-        self.gmail_creds = QLineEdit(self.config.get('GMAIL', 'credentials_file', fallback='credentials.json'))
-        layout.addRow('Gmail Credentials File:', self.gmail_creds)
-
-        # Exchange-Einstellungen
-        self.exchange_client_id = QLineEdit(self.config.get('EXCHANGE', 'client_id', fallback=''))
-        self.exchange_tenant_id = QLineEdit(self.config.get('EXCHANGE', 'tenant_id', fallback=''))
-        self.exchange_secret = QLineEdit(self.config.get('EXCHANGE', 'client_secret', fallback=''))
-        self.exchange_secret.setEchoMode(QLineEdit.EchoMode.Password)
-
-        layout.addRow('Exchange Client ID:', self.exchange_client_id)
-        layout.addRow('Exchange Tenant ID:', self.exchange_tenant_id)
-        layout.addRow('Exchange Client Secret:', self.exchange_secret)
-
-        # Buttons
-        buttons = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
-        )
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
-        layout.addRow(buttons)
-
-        self.setLayout(layout)
-
-    def get_settings(self):
-        return {
-            'client': self.client_combo.currentText(),
-            'gmail_credentials': self.gmail_creds.text(),
-            'exchange_client_id': self.exchange_client_id.text(),
-            'exchange_tenant_id': self.exchange_tenant_id.text(),
-            'exchange_secret': self.exchange_secret.text()
-        }
-
-class EmailListItem(QListWidgetItem):
-    def __init__(self, email_data, analysis_result):
-        super().__init__()
-        self.email_data = email_data
-        self.analysis_result = analysis_result
-        self.setText(f"{email_data['subject'][:50]}...")
-        self._set_color_by_threat_level()
-
-    def _set_color_by_threat_level(self):
-        level = self.analysis_result['level']
-        if level == THREAT_LEVELS["HIGH"]:
-            self.setBackground(QColor(255, 200, 200))  # Hellrot
-        elif level == THREAT_LEVELS["MEDIUM"]:
-            self.setBackground(QColor(255, 255, 200))  # Hellgelb
-        else:
-            self.setBackground(QColor(200, 255, 200))  # Hellgrün
+from .client_settings_dialog import ClientSettingsDialog
+from .email_list_item import EmailListItem
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    """Main application window for the Mail Analyzer."""
+
+    def __init__(self) -> None:
         super().__init__()
         self.analyzer = ThreatAnalyzer()
         self.traffic_light = TrafficLight()
         self.config = configparser.ConfigParser()
-        self.config.read('configuration.ini')
+        self.config.read("configuration.ini")
         self.scanner = get_scanner()
         self.update_manager = UpdateManager()
         self.report_generator = ReportGenerator()
+        self.email_controller = EmailController(self.scanner, self.analyzer)
+        self.report_controller = ReportController(self.report_generator)
 
         # Timer für automatische Updates
         self.update_check_timer = QTimer()
         self.update_check_timer.timeout.connect(self.check_for_updates)
         self.update_check_timer.start(86400000)  # Einmal täglich prüfen
 
-        self.initUI()
+        self._setup_ui()
 
         # Sofortige Update-Prüfung beim Start
         QTimer.singleShot(1000, self.check_for_updates)
 
-    def initUI(self):
-        self.setWindowTitle('Mail Analyzer')
+    def _setup_ui(self) -> None:
+        """Initialise widgets, layouts and menus."""
+        self.setWindowTitle("Mail Analyzer")
         self.setGeometry(100, 100, 1200, 800)
 
-        # Hauptlayout
         main_widget = QWidget()
         self.setCentralWidget(main_widget)
         layout = QHBoxLayout(main_widget)
 
-        # Splitter für flexible Größenanpassung
         splitter = QSplitter(Qt.Orientation.Horizontal)
         layout.addWidget(splitter)
 
-        # Linke Seite - E-Mail-Liste
+        splitter.addWidget(self._setup_left_panel())
+        splitter.addWidget(self._setup_tabs())
+        splitter.setSizes([400, 800])
+
+        self._load_initial_emails()
+        self._setup_menu()
+
+    def _setup_left_panel(self) -> QWidget:
+        """Create the left panel containing the email list."""
         left_widget = QWidget()
         left_layout = QVBoxLayout(left_widget)
 
-        # Client-Auswahl und Einstellungen
         client_layout = QHBoxLayout()
-        self.client_label = QLabel(f"Aktiver Client: {self.scanner._client.name if self.scanner._client else 'Nicht verbunden'}")
+        self.client_label = QLabel(
+            f"Aktiver Client: {self.scanner._client.name if self.scanner._client else 'Nicht verbunden'}"
+        )
         self.settings_button = QPushButton("Client Einstellungen")
         self.settings_button.clicked.connect(self.show_client_settings)
         client_layout.addWidget(self.client_label)
         client_layout.addWidget(self.settings_button)
         left_layout.addLayout(client_layout)
 
-        # Aktualisieren-Button und Fortschrittsanzeige
         refresh_layout = QHBoxLayout()
         self.refresh_button = QPushButton("Aktualisieren")
         self.refresh_button.clicked.connect(self.refresh_emails)
@@ -147,128 +105,103 @@ class MainWindow(QMainWindow):
         refresh_layout.addWidget(self.progress_bar)
         left_layout.addLayout(refresh_layout)
 
-        # E-Mail-Liste
         self.email_list = QListWidget()
         self.email_list.itemClicked.connect(self.show_email_details)
         left_layout.addWidget(self.email_list)
 
-        splitter.addWidget(left_widget)
+        return left_widget
 
-        # Rechte Seite - Details
+    def _setup_tabs(self) -> QWidget:
+        """Create the right panel with tabbed email details."""
         right_widget = QWidget()
         right_layout = QVBoxLayout(right_widget)
 
-        # Tabs für verschiedene Ansichten
         self.tab_widget = QTabWidget()
 
-        # Übersicht-Tab
         overview_tab = QWidget()
         overview_layout = QVBoxLayout(overview_tab)
         self.threat_level_label = QLabel()
-        self.threat_level_label.setFont(QFont('Arial', 14, QFont.Weight.Bold))
+        self.threat_level_label.setFont(QFont("Arial", 14, QFont.Weight.Bold))
         overview_layout.addWidget(self.threat_level_label)
 
         self.email_details = QTextEdit()
         self.email_details.setReadOnly(True)
         overview_layout.addWidget(self.email_details)
 
-        # Analyse-Tab
         analysis_tab = QWidget()
         analysis_layout = QVBoxLayout(analysis_tab)
         self.analysis_details = QTextEdit()
         self.analysis_details.setReadOnly(True)
         analysis_layout.addWidget(self.analysis_details)
 
-        # Rohdaten-Tab
         raw_tab = QWidget()
         raw_layout = QVBoxLayout(raw_tab)
         self.raw_email = QTextEdit()
         self.raw_email.setReadOnly(True)
         raw_layout.addWidget(self.raw_email)
 
-        # Tabs hinzufügen
         self.tab_widget.addTab(overview_tab, "Übersicht")
         self.tab_widget.addTab(analysis_tab, "Analyse")
         self.tab_widget.addTab(raw_tab, "Rohdaten")
 
         right_layout.addWidget(self.tab_widget)
-        splitter.addWidget(right_widget)
+        return right_widget
 
-        # Initiale Größenverteilung
-        splitter.setSizes([400, 800])
-
-        # Erste E-Mail-Liste laden
-        self.refresh_emails()
-
-        # Menüleiste erstellen
+    def _setup_menu(self) -> None:
+        """Configure the application menu bar."""
         menubar = self.menuBar()
 
-        # Hilfe-Menü
-        help_menu = menubar.addMenu('&Hilfe')
-
-        # Update-Aktion
-        check_update_action = QAction('Nach Updates suchen', self)
+        help_menu = menubar.addMenu("&Hilfe")
+        check_update_action = QAction("Nach Updates suchen", self)
         check_update_action.triggered.connect(self.check_for_updates)
         help_menu.addAction(check_update_action)
 
-        # Über-Aktion
-        about_action = QAction('Über Mail Analyzer', self)
+        about_action = QAction("Über Mail Analyzer", self)
         about_action.triggered.connect(self.show_about)
         help_menu.addAction(about_action)
 
-        # Berichte-Menü
-        reports_menu = menubar.addMenu('&Berichte')
-
-        # PDF-Bericht erstellen
-        pdf_report_action = QAction('PDF-Bericht erstellen', self)
+        reports_menu = menubar.addMenu("&Berichte")
+        pdf_report_action = QAction("PDF-Bericht erstellen", self)
         pdf_report_action.triggered.connect(self.create_pdf_report)
         reports_menu.addAction(pdf_report_action)
 
-        # Excel-Bericht erstellen
-        excel_report_action = QAction('Excel-Bericht erstellen', self)
+        excel_report_action = QAction("Excel-Bericht erstellen", self)
         excel_report_action.triggered.connect(self.create_excel_report)
         reports_menu.addAction(excel_report_action)
 
-        # Statistiken anzeigen
-        stats_action = QAction('Statistiken anzeigen', self)
+        stats_action = QAction("Statistiken anzeigen", self)
         stats_action.triggered.connect(self.show_statistics)
         reports_menu.addAction(stats_action)
 
         reports_menu.addSeparator()
+        auto_reports_menu = reports_menu.addMenu("Automatische Berichte")
 
-        # Automatische Berichte
-        auto_reports_menu = reports_menu.addMenu('Automatische Berichte')
-
-        daily_report_action = QAction('Täglicher Bericht aktivieren', self)
+        daily_report_action = QAction("Täglicher Bericht aktivieren", self)
         daily_report_action.setCheckable(True)
-        daily_report_action.triggered.connect(lambda: self.toggle_auto_reports('daily'))
+        daily_report_action.triggered.connect(lambda: self.toggle_auto_reports("daily"))
         auto_reports_menu.addAction(daily_report_action)
 
-        weekly_report_action = QAction('Wöchentlicher Bericht aktivieren', self)
+        weekly_report_action = QAction("Wöchentlicher Bericht aktivieren", self)
         weekly_report_action.setCheckable(True)
-        weekly_report_action.triggered.connect(lambda: self.toggle_auto_reports('weekly'))
+        weekly_report_action.triggered.connect(lambda: self.toggle_auto_reports("weekly"))
         auto_reports_menu.addAction(weekly_report_action)
 
-        # Menüleiste erweitern
-        menubar = self.menuBar()
-
-        # Ansicht-Menü
-        view_menu = menubar.addMenu('&Ansicht')
-
-        # Dashboard-Aktion
-        show_dashboard_action = QAction('Dashboard', self)
+        view_menu = menubar.addMenu("&Ansicht")
+        show_dashboard_action = QAction("Dashboard", self)
         show_dashboard_action.triggered.connect(self.show_dashboard)
         view_menu.addAction(show_dashboard_action)
 
-        # Einstellungen-Menü
-        settings_menu = menubar.addMenu('&Einstellungen')
-
-        # Kontext-Regeln
-        context_rules_action = QAction('Kontext-Regeln', self)
+        settings_menu = menubar.addMenu("&Einstellungen")
+        context_rules_action = QAction("Kontext-Regeln", self)
         context_rules_action.triggered.connect(self.show_context_rules)
         settings_menu.addAction(context_rules_action)
 
-    def show_client_settings(self):
+    def _load_initial_emails(self) -> None:
+        """Populate the email list on startup."""
+        self.refresh_emails()
+
+    def show_client_settings(self) -> None:
+        """Open the settings dialog for selecting the mail client."""
         dialog = ClientSettingsDialog(self.config, self)
         if dialog.exec():
             settings = dialog.get_settings()
@@ -286,28 +219,26 @@ class MainWindow(QMainWindow):
 
             # Scanner neu initialisieren
             self.scanner = get_scanner()
+            self.email_controller = EmailController(self.scanner, self.analyzer)
             self.refresh_emails()
 
-            self.client_label.setText(f"Aktiver Client: {self.scanner._client.name if self.scanner._client else 'Nicht verbunden'}")
+            self.client_label.setText(
+                f"Aktiver Client: {self.scanner._client.name if self.scanner._client else 'Nicht verbunden'}"
+            )
 
-    def refresh_emails(self):
-        """Aktualisiert die E-Mail-Liste"""
+    def refresh_emails(self) -> None:
+        """Refresh the email list by fetching and analysing messages."""
         self.progress_bar.show()
-        self.progress_bar.setRange(0, 0)  # Unbestimmter Fortschritt
+        self.progress_bar.setRange(0, 0)
         self.refresh_button.setEnabled(False)
 
         try:
             self.email_list.clear()
-            emails = self.scanner.get_emails(max_count=MAX_EMAILS_TO_SCAN)
-
-            for email in emails:
-                analysis = self.analyzer.analyze_email(email)
+            for email, analysis in self.email_controller.fetch_emails(MAX_EMAILS_TO_SCAN):
                 item = EmailListItem(email, analysis)
                 self.email_list.addItem(item)
-
-        except Exception as e:
-            QMessageBox.critical(self, "Fehler", f"Fehler beim Laden der E-Mails: {str(e)}")
-
+        except Exception as exc:  # pragma: no cover - GUI message box
+            QMessageBox.critical(self, "Fehler", f"Fehler beim Laden der E-Mails: {exc}")
         finally:
             self.progress_bar.hide()
             self.refresh_button.setEnabled(True)
@@ -417,70 +348,38 @@ class MainWindow(QMainWindow):
             "© 2025 Ihr Unternehmen"
         )
 
-    def create_pdf_report(self):
-        """Erstellt einen PDF-Bericht der aktuellen Analyse"""
+    def create_pdf_report(self) -> None:
+        """Generate a PDF report for the current email list."""
         try:
-            emails = []
-            for i in range(self.email_list.count()):
-                item = self.email_list.item(i)
-                email_data = item.email_data.copy()
-                email_data.update(item.analysis_result)
-                email_data['timestamp'] = datetime.now().isoformat()
-                emails.append(email_data)
-
-            filename = self.report_generator.create_pdf_report(emails)
+            filename = self.report_controller.create_pdf_report(self.email_list)
             if filename:
                 QMessageBox.information(
                     self,
                     "Bericht erstellt",
                     f"Der PDF-Bericht wurde erstellt unter:\n{filename}"
                 )
-                QDesktopServices.openUrl(QUrl.fromLocalFile(filename))  # Öffnet den Bericht
-        except Exception as e:
-            QMessageBox.critical(
-                self,
-                "Fehler",
-                f"Fehler bei der PDF-Erstellung: {str(e)}"
-            )
+                QDesktopServices.openUrl(QUrl.fromLocalFile(filename))
+        except Exception as exc:  # pragma: no cover - GUI message box
+            QMessageBox.critical(self, "Fehler", f"Fehler bei der PDF-Erstellung: {exc}")
 
-    def create_excel_report(self):
-        """Erstellt einen Excel-Bericht der aktuellen Analyse"""
+    def create_excel_report(self) -> None:
+        """Generate an Excel report for the current email list."""
         try:
-            emails = []
-            for i in range(self.email_list.count()):
-                item = self.email_list.item(i)
-                email_data = item.email_data.copy()
-                email_data.update(item.analysis_result)
-                email_data['timestamp'] = datetime.now().isoformat()
-                emails.append(email_data)
-
-            filename = self.report_generator.create_excel_report(emails)
+            filename = self.report_controller.create_excel_report(self.email_list)
             if filename:
                 QMessageBox.information(
                     self,
                     "Bericht erstellt",
                     f"Der Excel-Bericht wurde erstellt unter:\n{filename}"
                 )
-                QDesktopServices.openUrl(QUrl.fromLocalFile(filename))  # Öffnet den Bericht
-        except Exception as e:
-            QMessageBox.critical(
-                self,
-                "Fehler",
-                f"Fehler bei der Excel-Erstellung: {str(e)}"
-            )
+                QDesktopServices.openUrl(QUrl.fromLocalFile(filename))
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Fehler", f"Fehler bei der Excel-Erstellung: {exc}")
 
-    def show_statistics(self):
-        """Zeigt ein Fenster mit statistischen Auswertungen"""
+    def show_statistics(self) -> None:
+        """Display statistical summaries in a dialog."""
         try:
-            emails = []
-            for i in range(self.email_list.count()):
-                item = self.email_list.item(i)
-                email_data = item.email_data.copy()
-                email_data.update(item.analysis_result)
-                email_data['timestamp'] = datetime.now().isoformat()
-                emails.append(email_data)
-
-            stats = self.report_generator.create_statistical_analysis(emails)
+            stats = self.report_controller.create_statistical_analysis(self.email_list)
             if stats:
                 dialog = QDialog(self)
                 dialog.setWindowTitle("Statistische Auswertung")
@@ -490,28 +389,22 @@ class MainWindow(QMainWindow):
                 text = QTextEdit()
                 text.setReadOnly(True)
 
-                # Formatierte Statistiken
                 stats_text = "Statistische Auswertung\n\n"
                 stats_text += f"Gesamtzahl E-Mails: {stats['total_emails']}\n\n"
-
                 stats_text += "Bedrohungslevel:\n"
                 for level, count in stats['threat_levels'].items():
                     stats_text += f"- {level}: {count}\n"
 
                 stats_text += "\nHäufigste Indikatoren:\n"
                 sorted_indicators = sorted(
-                    stats['common_indicators'].items(),
-                    key=lambda x: x[1],
-                    reverse=True
+                    stats['common_indicators'].items(), key=lambda x: x[1], reverse=True
                 )[:10]
                 for indicator, count in sorted_indicators:
                     stats_text += f"- {indicator}: {count}\n"
 
                 stats_text += "\nHäufigste Absender-Domains:\n"
                 sorted_domains = sorted(
-                    stats['sender_domains'].items(),
-                    key=lambda x: x[1],
-                    reverse=True
+                    stats['sender_domains'].items(), key=lambda x: x[1], reverse=True
                 )[:10]
                 for domain, count in sorted_domains:
                     stats_text += f"- {domain}: {count}\n"
@@ -525,13 +418,8 @@ class MainWindow(QMainWindow):
 
                 dialog.setLayout(layout)
                 dialog.exec()
-
-        except Exception as e:
-            QMessageBox.critical(
-                self,
-                "Fehler",
-                f"Fehler bei der statistischen Analyse: {str(e)}"
-            )
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Fehler", f"Fehler bei der statistischen Analyse: {exc}")
 
     def toggle_auto_reports(self, period):
         """Aktiviert oder deaktiviert automatische Berichte"""

--- a/tests/test_email_controller.py
+++ b/tests/test_email_controller.py
@@ -1,0 +1,23 @@
+"""Tests for EmailController."""
+
+from analyzer.email_controller import EmailController
+
+
+class DummyScanner:
+    def __init__(self):
+        self.called_with = None
+
+    def get_emails(self, max_count: int):
+        self.called_with = max_count
+        return [{"subject": "test", "attachments": []}]
+
+
+class DummyAnalyzer:
+    def analyze_email(self, email):
+        return {"level": "LOW"}
+
+
+def test_fetch_emails_calls_dependencies():
+    controller = EmailController(DummyScanner(), DummyAnalyzer())
+    emails = controller.fetch_emails(5)
+    assert emails[0][1]["level"] == "LOW"

--- a/tests/test_report_controller.py
+++ b/tests/test_report_controller.py
@@ -1,0 +1,43 @@
+"""Tests for ReportController."""
+
+from analyzer.report_controller import ReportController
+
+
+class DummyItem:
+    def __init__(self):
+        self.email_data = {"subject": "s", "body": "b"}
+        self.analysis_result = {"level": "LOW"}
+
+
+class DummyListWidget:
+    def __init__(self):
+        self._items = [DummyItem()]
+
+    def count(self):
+        return len(self._items)
+
+    def item(self, index):
+        return self._items[index]
+
+
+class DummyGenerator:
+    def __init__(self):
+        self.received = None
+
+    def create_pdf_report(self, emails):
+        self.received = emails
+        return "file.pdf"
+
+    def create_excel_report(self, emails):  # pragma: no cover - not used in test
+        return "file.xlsx"
+
+    def create_statistical_analysis(self, emails):  # pragma: no cover - not used
+        return {"total_emails": len(emails)}
+
+
+def test_collects_emails_and_generates_pdf():
+    generator = DummyGenerator()
+    controller = ReportController(generator)
+    filename = controller.create_pdf_report(DummyListWidget())
+    assert filename == "file.pdf"
+    assert generator.received[0]["subject"] == "s"


### PR DESCRIPTION
## Summary
- extract client settings and email list item widgets into dedicated modules
- add email and report controllers to separate business logic from the GUI
- refactor main window setup and report generation for better modularity

## Testing
- `pytest`
- `flake8 analyzer gui tests` *(fails: command not found, installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688cfebc3d788328b703bc4d903ab0cb