### PR TITLE
[mail_analyzer] Refactor scanning and context utilities

### DIFF
--- a/analyzer/email_scanner.py
+++ b/analyzer/email_scanner.py
@@ -5,41 +5,35 @@ Verwaltet die E-Mail-Client-Integrationen und den Scan-Prozess
 import logging
 import configparser
 import re
-from typing import List, Dict
+from contextlib import contextmanager
+from typing import Dict, List
+
+from config import settings
 from .email_clients.base import EmailClientBase
 from .email_clients.outlook import OutlookClient
 from .email_clients.gmail import GmailClient
 from .email_clients.exchange import ExchangeOnlineClient
 
-SUSPICIOUS_KEYWORDS = (
-    "dringend",
-    "sofort",
-    "passwort",
-    "konto",
-    "überweisen",
-    "zahlung",
-    "gewinnen",
-    "klicken",
-    "anhang öffnen",
-    "verifizieren",
-    "bestätigen",
-    "sicherheitswarnung",
-    "bank",
-    "rechnung",
-    "ungewöhnlich",
-    "gesperrt",
+# Suspicious markers are loaded from configuration to ease localization and updates
+SUSPICIOUS_KEYWORDS = tuple(
+    kw.lower()
+    for keywords in settings.SUSPICIOUS_KEYWORDS.values()
+    for kw in keywords
 )
-SUSPICIOUS_EXTENSIONS = (".exe", ".bat", ".js", ".vbs", ".scr", ".zip", ".rar")
+SUSPICIOUS_EXTENSIONS = tuple(
+    ext.lower()
+    for exts in settings.SUSPICIOUS_EXTENSIONS.values()
+    for ext in exts
+)
 
 URL_PATTERN = re.compile(r"https?://[^\s]+")
 SHORTENER_PATTERN = re.compile(r"(bit\.ly|tinyurl|goo\.gl|ow\.ly)", re.IGNORECASE)
 SUSPICIOUS_LINK_PATTERN = re.compile(r"(login|verify|secure|bank|konto)", re.IGNORECASE)
 
 class EmailScanner:
-    def __init__(self, config_file: str = 'configuration.ini'):
+    def __init__(self, config_file: str = "configuration.ini"):
         self.config = configparser.ConfigParser()
         self.config.read(config_file)
-        self._client = None
 
     def _initialize_client(self) -> EmailClientBase:
         """Initialisiert den konfigurierten E-Mail-Client"""
@@ -58,29 +52,32 @@ class EmailScanner:
         else:
             raise ValueError(f"Nicht unterstützter E-Mail-Client: {client_type}")
 
-    def get_emails(self, max_count: int = 20) -> List[Dict]:
-        """
-        Ruft E-Mails vom konfigurierten Client ab
-        """
+    @contextmanager
+    def _client_context(self) -> EmailClientBase:
+        """Provide a connected mail client and ensure cleanup."""
+        client = self._initialize_client()
+        logging.info(f"Initialisiere {client.name} Client")
+        if not client.connect():
+            raise ConnectionError(f"Verbindung zu {client.name} fehlgeschlagen")
         try:
-            if not self._client:
-                self._client = self._initialize_client()
-                logging.info(f"Initialisiere {self._client.name} Client")
-
-            if not self._client.connect():
-                raise ConnectionError(f"Verbindung zu {self._client.name} fehlgeschlagen")
-
-            emails = self._client.get_emails(max_count)
-            logging.info(f"{len(emails)} E-Mails von {self._client.name} abgerufen")
-            return emails
-
-        except Exception as e:
-            logging.error(f"Fehler beim Abrufen der E-Mails: {str(e)}")
-            return []
-
+            yield client
         finally:
-            if self._client:
-                self._client.disconnect()
+            client.disconnect()
+
+    def get_emails(self, max_count: int = 20) -> List[Dict]:
+        """Ruft E-Mails vom konfigurierten Client ab."""
+        try:
+            with self._client_context() as client:
+                emails = client.get_emails(max_count)
+                logging.info(
+                    f"{len(emails)} E-Mails von {client.name} abgerufen"
+                )
+                return emails
+        except ConnectionError as exc:
+            logging.error(f"Verbindungsfehler: {exc}")
+        except Exception as exc:  # Fallback for unerwartete Fehler
+            logging.error(f"Fehler beim Abrufen der E-Mails: {exc}")
+        return []
 
 def scan_email(email, trusted_domains=None):
     """Analyze an email for potential security issues and determine its risk level.
@@ -157,12 +154,10 @@ def determine_risk_level(issues: List[str]) -> str:
         return "yellow"
     return "green"
 
-def scan_inbox(folder_name: str = "Posteingang", max_count: int = 20, trusted_domains=None):
+def scan_inbox(max_count: int = 20, trusted_domains=None):
     """Scannt E-Mails im Posteingang und bewertet deren Risiko.
 
     Args:
-        folder_name (str): Name des Outlook-Ordners. Der Parameter ist
-            aktuell nur ein Platzhalter und hat keine Auswirkung.
         max_count (int): Maximale Anzahl abzurufender E-Mails.
         trusted_domains (list[str] | None): Liste vertrauenswürdiger Domains,
             die bei der Bewertung berücksichtigt werden.

--- a/config/settings.py
+++ b/config/settings.py
@@ -53,7 +53,7 @@ SUSPICIOUS_KEYWORDS = {
 
 SUSPICIOUS_URL_PATTERNS = [
     r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
-    r'(?:https?://)?(?:[\w-]+\.)+[\w-]+(?:/[\w-./?%&=]*)?'
+    r'(?:https?://)?(?:[\w-]+\.)+[\w-]+(?:/[\w./?%&=-]*)?'
 ]
 
 SUSPICIOUS_TLD = [

--- a/tests/test_email_scanner.py
+++ b/tests/test_email_scanner.py
@@ -101,7 +101,7 @@ def test_scan_inbox_uses_max_count(monkeypatch):
     mock_get = MagicMock(return_value=[dummy_email])
     monkeypatch.setattr(analyzer.email_scanner, "get_outlook_emails", mock_get)
 
-    results = scan_inbox(folder_name="ignored", max_count=5)
+    results = scan_inbox(max_count=5)
 
     mock_get.assert_called_once_with(max_count=5)
     assert results[0]["subject"] == "Hallo"


### PR DESCRIPTION
## Summary
- load scanner keywords and extensions from config and use a client context manager
- extract department weights and simplify directory creation for context analyzer
- expose feedback learner weights and persist model version by timestamp
- drop unused inbox folder parameter and fix invalid URL regex

## Testing
- `flake8 analyzer gui tests` *(fails: line length and style violations)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d0e71af308328bb1ec9e5e1321849