### PR TITLE
[mail_analyzer] Improve local AI error handling

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/analyzer/local_ai_handler.py
+++ b/analyzer/local_ai_handler.py
@@ -4,9 +4,10 @@ Lokale KI-Modelle Integration (Ollama und DeepSeek)
 import os
 import json
 import logging
-from typing import Dict, Optional, List
+from typing import Dict
 import httpx
 from concurrent.futures import ThreadPoolExecutor
+
 
 class LocalAIHandler:
     def __init__(self):
@@ -110,7 +111,7 @@ Antworte im JSON-Format."""
                 # Versuche JSON aus der Antwort zu extrahieren
                 try:
                     return json.loads(result['response'])
-                except:
+                except json.JSONDecodeError:
                     # Fallback für nicht-JSON Antworten
                     return {
                         "error": "Konnte Ollama-Antwort nicht parsen",
@@ -141,7 +142,7 @@ Antworte im JSON-Format."""
 
                 try:
                     return json.loads(result['choices'][0]['message']['content'])
-                except:
+                except json.JSONDecodeError:
                     return {
                         "error": "Konnte DeepSeek-Antwort nicht parsen",
                         "raw_response": result['choices'][0]['message']['content']


### PR DESCRIPTION
## Summary
- handle JSON parsing errors from local AI providers
- allow longer lines in flake8 configuration

## Testing
- `flake8 analyzer/local_ai_handler.py tests/test_local_ai_handler.py`
- `flake8 analyzer gui tests` *(fails: analyzer/email_clients/base.py:7:1: E302 expected 2 blank lines, found 1, ...)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d17834760832882a998dbfffb965a