### PR TITLE
[mail_analyzer] Centralize threat level calculation

### DIFF
--- a/analyzer/threat_analyzer.py
+++ b/analyzer/threat_analyzer.py
@@ -11,10 +11,15 @@ from .threat_intelligence import ThreatIntelligence
 from .context_analyzer import ContextAwareAnalyzer
 from .threat_clustering import ThreatClusterAnalyzer
 from .proactive_defense import ProactiveThreatDefense
+from .utils import get_threat_level
 from config.settings import (
-    THREAT_LEVELS, SUSPICIOUS_EXTENSIONS, SUSPICIOUS_KEYWORDS,
-    SUSPICIOUS_URL_PATTERNS, SUSPICIOUS_TLD, SCORING_WEIGHTS
+    SUSPICIOUS_EXTENSIONS,
+    SUSPICIOUS_KEYWORDS,
+    SUSPICIOUS_URL_PATTERNS,
+    SUSPICIOUS_TLD,
+    SCORING_WEIGHTS,
 )
+
 
 class ThreatAnalyzer:
     def __init__(self):
@@ -94,7 +99,7 @@ class ThreatAnalyzer:
 
         return {
             'score': round(self.threat_score, 2),
-            'level': self._get_threat_level(),
+            'level': get_threat_level(self.threat_score, use_icon=True),
             'indicators': self.threat_indicators,
             'analyzed_urls': list(self.urls_found),
             'ml_confidence': ml_confidence,
@@ -310,10 +315,3 @@ class ThreatAnalyzer:
 
         return score
 
-    def _get_threat_level(self) -> str:
-        """Bestimmt das Bedrohungslevel basierend auf dem Score"""
-        if self.threat_score >= 7.0:
-            return THREAT_LEVELS["HIGH"]
-        elif self.threat_score >= 4.0:
-            return THREAT_LEVELS["MEDIUM"]
-        return THREAT_LEVELS["LOW"]

--- a/analyzer/utils.py
+++ b/analyzer/utils.py
@@ -5,8 +5,10 @@ import logging
 from logging.handlers import RotatingFileHandler
 import os
 from datetime import datetime
-from config.settings import LOG_FILE, LOG_FORMAT
 import re
+
+from config.settings import LOG_FILE, LOG_FORMAT
+
 
 def setup_logging():
     """Konfiguriert das Logging-System"""
@@ -34,44 +36,104 @@ def setup_logging():
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
 
+
 def format_timestamp(timestamp):
     """Formatiert einen Zeitstempel in lesbares Format"""
     return datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
 
+
 def sanitize_filename(filename):
     """Bereinigt Dateinamen von ungültigen Zeichen"""
-    return "".join(c for c in filename if c.isalnum() or c in (' ', '-', '_', '.'))
+    return "".join(
+        c for c in filename if c.isalnum() or c in (" ", "-", "_", ".")
+    )
+
 
 def create_analysis_report(email_data, threat_analysis):
-    """Erstellt einen formatierten Analysebericht"""
+    """Erstellt einen formatierten Analysebericht."""
     return {
         "timestamp": format_timestamp(datetime.now().timestamp()),
         "email": {
             "subject": email_data.get("subject", ""),
             "sender": email_data.get("sender", ""),
-            "attachment_count": len(email_data.get("attachments", []))
+            "attachment_count": len(email_data.get("attachments", [])),
         },
-        "analysis": threat_analysis
+        "analysis": threat_analysis,
     }
+
 
 def extract_links(text):
     """
     Extracts all URLs from the given text.
     """
-    return re.findall(r'https?://[^\s]+', text or "")
+    return re.findall(r"https?://[^\s]+", text or "")
+
 
 def is_suspicious_sender(sender, trusted_domains=None):
+    """Check if the sender is suspicious.
+
+    Args:
+        sender: Sender email address.
+        trusted_domains: Optional list of trusted domains.
+
+    Returns:
+        bool: ``True`` if the sender is not from a trusted domain.
     """
-    Checks if the sender is suspicious (not in trusted domains).
-    """
+
     if trusted_domains is None:
         trusted_domains = ["@ihrefirma.de", "@vertrauenswuerdig.de"]
+
     return not any(sender.endswith(domain) for domain in trusted_domains)
 
+
 def has_suspicious_attachment(attachments, suspicious_extensions=None):
+    """Check if any attachment has a suspicious file extension.
+
+    Args:
+        attachments: List of attachment filenames.
+        suspicious_extensions: Optional list of extensions considered risky.
+
+    Returns:
+        bool: ``True`` if any attachment has a suspicious extension.
     """
-    Checks if any attachment has a suspicious file extension.
-    """
+
     if suspicious_extensions is None:
-        suspicious_extensions = [".exe", ".bat", ".js", ".vbs", ".scr", ".zip", ".rar"]
-    return any(att.lower().endswith(tuple(suspicious_extensions)) for att in attachments)
+        suspicious_extensions = [
+            ".exe",
+            ".bat",
+            ".js",
+            ".vbs",
+            ".scr",
+            ".zip",
+            ".rar",
+        ]
+
+    return any(
+        att.lower().endswith(tuple(suspicious_extensions))
+        for att in attachments
+    )
+
+
+def get_threat_level(score, use_icon=False):
+    """Return threat level for a given score.
+
+    Args:
+        score (float): Threat score on a 0-10 scale.
+        use_icon (bool): If ``True``, return the corresponding icon instead of
+            the textual level.
+
+    Returns:
+        str: Threat level as text (``"LOW"``, ``"MEDIUM"``, ``"HIGH"``) or as
+            an icon when ``use_icon`` is ``True``.
+    """
+
+    from config.settings import THREAT_LEVELS
+
+    if score >= 7.0:
+        level = "HIGH"
+    elif score >= 4.0:
+        level = "MEDIUM"
+    else:
+        level = "LOW"
+
+    return THREAT_LEVELS[level] if use_icon else level

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,74 +1,110 @@
-"""
-Test-Suite für die Utility-Funktionen
-"""
-import pytest
+"""Test-Suite für die Utility-Funktionen."""
+
 import os
+from datetime import datetime
+
 from analyzer.utils import (
     setup_logging,
     format_timestamp,
     sanitize_filename,
     create_analysis_report,
     extract_links,
-    is_suspicious_sender
+    is_suspicious_sender,
+    get_threat_level,
 )
-from datetime import datetime
+
 
 def test_setup_logging(tmp_path):
-    """Test der Logging-Konfiguration"""
+    """Test der Logging-Konfiguration."""
     log_file = tmp_path / "test.log"
     os.environ["LOG_FILE"] = str(log_file)
     setup_logging()
     assert log_file.parent.exists(), "Log-Verzeichnis sollte erstellt werden"
 
+
 def test_format_timestamp():
-    """Test der Zeitstempel-Formatierung"""
+    """Test der Zeitstempel-Formatierung."""
     test_timestamp = datetime.now().timestamp()
     formatted = format_timestamp(test_timestamp)
-    assert isinstance(formatted, str), "Formatierter Zeitstempel sollte ein String sein"
-    assert len(formatted) == 19, "Zeitstempel sollte im Format 'YYYY-MM-DD HH:MM:SS' sein"
+    assert isinstance(
+        formatted, str
+    ), "Formatierter Zeitstempel sollte ein String sein"
+    assert (
+        len(formatted) == 19
+    ), "Zeitstempel sollte im Format 'YYYY-MM-DD HH:MM:SS' sein"
+
 
 def test_sanitize_filename():
-    """Test der Dateinamen-Bereinigung"""
+    """Test der Dateinamen-Bereinigung."""
     test_filename = "Test/File*With:Invalid<Chars>.txt"
     sanitized = sanitize_filename(test_filename)
-    assert "/" not in sanitized, "Sanitized Filename sollte keine Schrägstriche enthalten"
-    assert "*" not in sanitized, "Sanitized Filename sollte keine Sternchen enthalten"
-    assert ":" not in sanitized, "Sanitized Filename sollte keine Doppelpunkte enthalten"
-    assert "<" not in sanitized, "Sanitized Filename sollte keine spitzen Klammern enthalten"
+    assert "/" not in sanitized, (
+        "Sanitized Filename sollte keine Schrägstriche enthalten"
+    )
+    assert "*" not in sanitized, (
+        "Sanitized Filename sollte keine Sternchen enthalten"
+    )
+    assert ":" not in sanitized, (
+        "Sanitized Filename sollte keine Doppelpunkte enthalten"
+    )
+    assert "<" not in sanitized, (
+        "Sanitized Filename sollte keine spitzen Klammern enthalten"
+    )
+
 
 def test_create_analysis_report():
-    """Test der Berichtserstellung"""
+    """Test der Berichtserstellung."""
     test_email = {
         "subject": "Test Subject",
         "sender": "test@example.com",
-        "attachments": ["test.txt"]
+        "attachments": ["test.txt"],
     }
     test_analysis = {
         "score": 3,
         "level": "🟢",
-        "indicators": ["Test Indicator"]
+        "indicators": ["Test Indicator"],
     }
-    
+
     report = create_analysis_report(test_email, test_analysis)
     assert isinstance(report, dict), "Bericht sollte ein Dictionary sein"
     assert "timestamp" in report, "Bericht sollte einen Zeitstempel enthalten"
     assert "email" in report, "Bericht sollte E-Mail-Daten enthalten"
     assert "analysis" in report, "Bericht sollte Analyse-Daten enthalten"
 
+
 def test_extract_links():
-    """Test der URL-Extraktion"""
+    """Test der URL-Extraktion."""
     test_text = "Text mit http://example.com und https://test.com/page Links"
     links = extract_links(test_text)
     assert len(links) == 2, "Sollte zwei Links finden"
     assert "http://example.com" in links, "Sollte den ersten Link enthalten"
-    assert "https://test.com/page" in links, "Sollte den zweiten Link enthalten"
+    assert "https://test.com/page" in links, (
+        "Sollte den zweiten Link enthalten"
+    )
+
 
 def test_is_suspicious_sender():
-    """Test der Absender-Überprüfung"""
+    """Test der Absender-Überprüfung."""
     trusted_domains = ["@trusted.com", "@safe.org"]
-    
-    assert is_suspicious_sender("user@malicious.com", trusted_domains), \
-        "Unbekannte Domain sollte als verdächtig eingestuft werden"
-    
-    assert not is_suspicious_sender("user@trusted.com", trusted_domains), \
-        "Vertrauenswürdige Domain sollte nicht als verdächtig eingestuft werden"
+
+    assert is_suspicious_sender(
+        "user@malicious.com", trusted_domains
+    ), "Unbekannte Domain sollte als verdächtig eingestuft werden"
+
+    assert not is_suspicious_sender(
+        "user@trusted.com", trusted_domains
+    ), "Vertrauenswürdige Domain sollte nicht als verdächtig eingestuft werden"
+
+
+def test_get_threat_level():
+    """Testet die Bestimmung des Bedrohungslevels."""
+    assert get_threat_level(8.5) == "HIGH"
+    assert get_threat_level(5.0) == "MEDIUM"
+    assert get_threat_level(1.0) == "LOW"
+
+
+def test_get_threat_level_icon():
+    """Testet die Rückgabe von Icons für Bedrohungslevel."""
+    assert get_threat_level(8.5, use_icon=True) == "🔴"
+    assert get_threat_level(5.0, use_icon=True) == "🟡"
+    assert get_threat_level(1.0, use_icon=True) == "🟢"


### PR DESCRIPTION
## Summary
- factor out reusable `get_threat_level` utility
- use shared helper in threat and report analyzers
- add unit tests for threat level helper

## Testing
- `pytest`
- `flake8 analyzer/utils.py analyzer/report_generator.py tests/test_utils.py analyzer/threat_analyzer.py` *(fails: line too long in analyzer/threat_analyzer.py)*

------
https://chatgpt.com/codex/tasks/task_e_688d16f5506083288aebf43ca91149a0