### PR TITLE
[mail_analyzer] Add project documentation and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python cache and bytecode
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+
+# Test and coverage artifacts
+.pytest_cache/
+.coverage
+
+# OS files
+.DS_Store
+
+# Logs and models
+logs/
+models/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Mail Analyzer
+
+Mail Analyzer scans incoming emails, evaluates potential threats using rule-based and machine-learning techniques, and presents results in a desktop GUI.
+
+## Features
+- Connectors for Outlook, Gmail, and Exchange
+- Hybrid threat analysis with heuristics and scikit-learn models
+- Optional local AI enrichment via HTTP APIs
+- PyQt6 interface with dashboards and reports
+
+## Installation
+1. Create and activate a virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Optionally install development tools:
+   ```bash
+   pip install -e .[dev]
+   ```
+
+## Usage
+Run the GUI entry point:
+```bash
+python -m gui.main_window
+```
+
+## Documentation
+Additional documents live in the [`docs/`](docs/) directory:
+- [Project Overview](docs/project_overview.md)
+- [Request Flow](docs/request_flow.md)
+
+## Testing
+Execute the full test suite and linter from the repository root:
+```bash
+pytest
+flake8 analyzer gui tests
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Documentation Index
+
+This directory contains supplemental documentation for Mail Analyzer.
+
+## Contents
+- [Project Overview](project_overview.md): architecture and component summary
+- [Request Flow](request_flow.md): end-to-end message processing
+- [Installation](#installation)
+- [Running Tests](#running-tests)
+
+## Installation
+Follow the steps from the repository README to install dependencies. Afterwards, configure email credentials in `config/settings.py` as needed.
+
+## Running Tests
+From the project root execute:
+```bash
+pytest
+flake8 analyzer gui tests
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "mail_analyzer"
+version = "0.1.0"
+description = "Email threat analysis and reporting tool with GUI"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "numpy",
+    "pandas",
+    "matplotlib",
+    "joblib",
+    "httpx",
+    "requests",
+    "schedule",
+    "scikit-learn",
+    "PyQt6",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "flake8",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+numpy
+pandas
+matplotlib
+joblib
+httpx
+requests
+schedule
+scikit-learn
+PyQt6


### PR DESCRIPTION
## Summary
- add project overview README and documentation index
- define runtime and development dependencies
- introduce standard gitignore and packaging metadata

## Testing
- `pytest`
- `flake8 analyzer gui tests` *(fails: E302 expected 2 blank lines, F401 unused imports, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688d204854f48328afb05ed3db65013e